### PR TITLE
Evalution task - make changes between tab become independent for 'Clock' component

### DIFF
--- a/src/app/templates/clock-setting/clock-setting.component.html
+++ b/src/app/templates/clock-setting/clock-setting.component.html
@@ -93,21 +93,6 @@
                 </div>
               </div>
             </form>
-
-            <div class="row">
-              <div class="col-12 footer-btn-position">
-                <button
-                  type="button"
-                  class="btn btn-secondary mr-20"
-                  (click)="dismissModel()"
-                >
-                  CANCEL
-                </button>
-                <button class="btn btn-primary" (click)="saveClockSettings()">
-                  SAVE
-                </button>
-              </div>
-            </div>
           </div>
 
           <div
@@ -125,6 +110,21 @@
           </div>
         </div>
       </div>
+
+      <div class="row">
+        <div class="col-12 footer-btn-position">
+          <button
+                  type="button"
+                  class="btn btn-secondary mr-20"
+                  (click)="dismissModel()">
+            CANCEL
+          </button>
+          <button class="btn btn-primary" (click)="saveClockSettings()">
+            SAVE
+          </button>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/src/app/templates/clock-setting/clock-setting.component.ts
+++ b/src/app/templates/clock-setting/clock-setting.component.ts
@@ -4,7 +4,7 @@ import {
   Input,
   OnChanges,
   Output,
-  EventEmitter,
+  EventEmitter, ViewChild,
 } from "@angular/core";
 import { WidgetService } from "src/app/service/widget.service";
 import { ToastrService } from "ngx-toastr";
@@ -17,6 +17,7 @@ import * as moment_t from "moment-timezone";
 import { Ng4LoadingSpinnerService } from "ng4-loading-spinner";
 import { ClockService } from "src/app/service/clock.service";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { WidgetBgSettingComponent } from '../widget-bg-setting/widget-bg-setting.component';
 
 @Component({
   selector: "app-clock-setting",
@@ -30,6 +31,8 @@ export class ClockSettingComponent implements OnInit, OnChanges {
   @Input() clockWidgetObject: any;
   @Input() changeDetector: any;
   @Output() updateClockEventEmiter = new EventEmitter();
+  @ViewChild(WidgetBgSettingComponent, { static: false })
+  bgSettingComponent!: WidgetBgSettingComponent;
 
   clockEnabled: boolean;
   greetingsEnabled: boolean = false;
@@ -178,7 +181,13 @@ export class ClockSettingComponent implements OnInit, OnChanges {
   }
 
   saveClockSettings() {
+    this.bgSettingComponent.onBackgroundOptionEmit();
     let payload = this.clockFormGroup.value;
+
+    if(this.bgSettingComponent.areSettingsIdentical(payload, this.clockWidgetData)){
+      return;
+    }
+
     payload["id"] = this.clockWidgetData.id;
     payload["widgetSetting"] = {
       id: this.clockWidgetObject.widgetSettingId,

--- a/src/app/templates/widget-bg-setting/widget-bg-setting.component.html
+++ b/src/app/templates/widget-bg-setting/widget-bg-setting.component.html
@@ -440,18 +440,3 @@
     </div>
   </div>
 </div>
-
-<div class="row">
-  <div class="col-12 footer-btn-position">
-    <button
-      type="button"
-      class="btn btn-secondary mr-20"
-      (click)="dismissModel()"
-    >
-      CANCEL
-    </button>
-    <button class="btn btn-primary" (click)="onBackgroundOptionEmit()">
-      SAVE
-    </button>
-  </div>
-</div>

--- a/src/app/templates/widget-bg-setting/widget-bg-setting.component.ts
+++ b/src/app/templates/widget-bg-setting/widget-bg-setting.component.ts
@@ -127,6 +127,8 @@ export class WidgetBgSettingComponent
     "mealplan",
   ];
 
+  storedWidgetbgsetting: any ;
+
   constructor() {
     let defaultFontFamily = {
       id: 0,
@@ -184,8 +186,17 @@ export class WidgetBgSettingComponent
     }
 
     if (changes.widgetbgsetting !== undefined) {
-      if (changes.widgetbgsetting.currentValue !== undefined) {
-        this.bgSettingOptions = changes.widgetbgsetting.currentValue;
+
+      const currentValue = changes.widgetbgsetting.currentValue;
+      const previousValue = changes.widgetbgsetting.previousValue;
+     
+      if (this.areSettingsIdentical(currentValue, previousValue)) {
+        return;
+      }
+
+      if (currentValue !== undefined) {
+        this.bgSettingOptions = { ...currentValue };
+        this.storedWidgetbgsetting = { ...currentValue };
 
         if (this.bgSettingOptions.widgetname == undefined) {
           this.bgSettingOptions["widgetname"] = "";
@@ -248,6 +259,10 @@ export class WidgetBgSettingComponent
       this.bgSettingOptions.isNameVisible = false;
     }
 
+    if(this.areSettingsIdentical(this.bgSettingOptions, this.storedWidgetbgsetting)){
+      return;
+    }
+
     if (this.widgetType.toLowerCase() === "calendar") {
       this.emitbgsettingCalenderOptions.emit(this.bgSettingOptions);
     } else if (this.widgetType.toLowerCase() === "clock") {
@@ -301,4 +316,24 @@ export class WidgetBgSettingComponent
   dismissModel() {
     this.closeModalEvent.emit(true);
   }
+
+
+  // Can be create a service or utils file for this method
+  areSettingsIdentical(currentValue: any, previousValue: any): boolean { 
+    // If both values exist, compare them
+    if (currentValue && previousValue) {
+      // Check if all properties are identical
+      const areSettingsEqual = Object.keys(currentValue).every(key =>
+          currentValue[key] === previousValue[key]
+      );
+
+      // If settings are identical, return early
+      if (areSettingsEqual) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+
 }


### PR DESCRIPTION
The changes primarily focus on **app-widget-bg-setting** since this component will be used across all templates. There are two main updates:

The save button has been removed to avoid having a separate save button for each tab.
A validation check has been added to detect changes in app-widget-bg-setting. If a change is detected, we automatically call the same API that was previously triggered by the removed button.
For the Clock component, when the save button is clicked, it will now emit the same event that was previously triggered by the removed button. To avoid unnecessary API calls, a check is performed to determine if the settings have changed before making a request.

Other components can follow the same approach as the Clock component by using:


``  @ViewChild(WidgetBgSettingComponent, { static: false })
  bgSettingComponent!: WidgetBgSettingComponent;
```

and on the save for each component:
` saveComponentNameSettings() {
    this.bgSettingComponent.onBackgroundOptionEmit();
    let payload = this.FormGroup.value;

    if(this.bgSettingComponent.areSettingsIdentical(payload, initialData)){
      return;
    }
`
