### PR TITLE
Evaluation task

### DIFF
--- a/src/app/enum/components.enum.ts
+++ b/src/app/enum/components.enum.ts
@@ -1,0 +1,9 @@
+/**
+ * @description
+ * Enum representing different components that can be registered for save operations.
+ * Used in conjunction with `CentralSaveService` to identify and trigger saves for specific components.
+ */
+export enum Components {
+    WIDGET_BG_SETTING,
+    CLOCK_SETTING
+}

--- a/src/app/service/central-save.service.spec.ts
+++ b/src/app/service/central-save.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CentralSaveService } from './central-save.service';
+
+describe('CentralSaveService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: CentralSaveService = TestBed.get(CentralSaveService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/service/central-save.service.ts
+++ b/src/app/service/central-save.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+import { Components } from '../enum/components.enum';
+
+/**
+ * @description
+ * Centralized service to manage save triggers for multiple components.
+ * Allows components to register themselves for save operations and 
+ * notifies them when a save is triggered.
+ *
+ * @example
+ * // Inject the service in a component
+ * constructor(private centralSaveService: CentralSaveService) {}
+ *
+ * // Register component for save notifications
+ * this.centralSaveService.registerSave(Components.MyComponent);
+ *
+ * // Subscribe to save trigger
+ * this.centralSaveService.saveTriggered$.subscribe(component => {
+ *   if (component === Components.MyComponent) {
+ *     this.saveData();
+ *   }
+ * });
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class CentralSaveService {
+
+  /**
+   * List of registered components that require save operations.
+   */
+  private components: Components[] = [];
+
+  /**
+   * Subject used to notify registered components when a save operation is triggered.
+   */
+  private saveTrigger = new Subject<Components>();
+
+  /**
+   * Observable that emits when a save is triggered for a component.
+   */
+  saveTriggered$ = this.saveTrigger.asObservable();
+
+  /**
+   * Subject used to handle unsubscription logic.
+   */
+  unsubscribe$ = new Subject<void>();
+
+  /**
+   * Registers a component for save operations.
+   * Ensures that the component is only added once.
+   *
+   * @param componentName - The component to register.
+   */
+  registerSave(componentName: Components) {
+    if (!this.components.includes(componentName)) {
+      this.components.push(componentName);
+    }
+  }
+
+  /**
+   * Triggers save for all registered components by emitting a save event.
+   * Also resets the unsubscription subject.
+   */
+  triggerSave() {
+    this.unsubscribe$ = new Subject<void>();
+    this.components.forEach(component => this.saveTrigger.next(component));
+    this.unsubscribe();
+  }
+
+  /**
+   * Clears the registered components list and completes the unsubscription subject.
+   */
+  clear() {
+    this.components = [];
+    this.unsubscribe();
+  }
+
+  /**
+   * Completes the `unsubscribe$` subject to prevent memory leaks.
+   */
+  private unsubscribe() {
+    this.unsubscribe$.complete();
+  }
+
+}

--- a/src/app/templates/clock-setting/clock-setting.component.html
+++ b/src/app/templates/clock-setting/clock-setting.component.html
@@ -103,7 +103,7 @@
                 >
                   CANCEL
                 </button>
-                <button class="btn btn-primary" (click)="saveClockSettings()">
+                <button class="btn btn-primary" (click)="save()">
                   SAVE
                 </button>
               </div>

--- a/src/app/templates/widget-bg-setting/widget-bg-setting.component.html
+++ b/src/app/templates/widget-bg-setting/widget-bg-setting.component.html
@@ -450,7 +450,7 @@
     >
       CANCEL
     </button>
-    <button class="btn btn-primary" (click)="onBackgroundOptionEmit()">
+    <button class="btn btn-primary" (click)="save()">
       SAVE
     </button>
   </div>

--- a/src/app/widget/layout-component/layout-component.component.ts
+++ b/src/app/widget/layout-component/layout-component.component.ts
@@ -26,6 +26,7 @@ import { takeUntil } from "rxjs/operators";
 import { Observable, Subject, Subscription } from "rxjs";
 import { MangoMirrorConstants } from "src/app/util/constants";
 import { DragulaService } from "ng2-dragula";
+import { CentralSaveService } from "src/app/service/central-save.service";
 
 declare var StripeCheckout: any;
 
@@ -240,7 +241,8 @@ export class LayoutComponentComponent implements OnInit {
     private activeRouter: ActivatedRoute,
     private _widgetUtil: WidgetsUtil,
     private _subscriptionUtil: SubscriptionUtil,
-    private dragulaService: DragulaService
+    private dragulaService: DragulaService,
+    private _centralSaveService: CentralSaveService
   ) {
     try {
       this.dragulaService.createGroup("pagecontainer", {
@@ -1072,6 +1074,8 @@ export class LayoutComponentComponent implements OnInit {
         } else {
           this.clockWidgetObject = this.createWidgetSetting(category);
         }
+        // When the clock setting modal is hidden, clear all registered components from CentralSaveService.
+        this.clockSettingModal.onHidden.subscribe(() => this._centralSaveService.clear());
         break;
       case "news":
         this.newsChangeDetector = !this.newsChangeDetector;


### PR DESCRIPTION
### **🛠 How to Integrate Centralized Save Service in Other Widgets?**
The Centralized Save Service allows widgets to register themselves and respond to global save triggers. Follow these steps to integrate it into any widget. 🚀

### **📌 Step 1: Add Your Widget to the Enum**
To register a new widget, update the `Components` enum.
🗂 **File Path:** `src/app/enum/components.enum.ts`
```
export enum Components {
    WIDGET_BG_SETTING,
    CLOCK_SETTING,
    MY_WIDGET  // 👈 Add your widget here
}
```

🔹 **Replace MY_WIDGET with your actual widget name.**

### 📥 **Step 2: Inject CentralSaveService in Your Component**
Inject `CentralSaveService `in the constructor:
`constructor(private _centralSaveService: CentralSaveService) {}`

### 🔗 **Step 3: Register the Widget for Save Operations**
Inside `ngOnInit()`, register the widget so it listens for global save triggers.

```
ngOnInit() {
    this._centralSaveService.registerSave(Components.MY_WIDGET);

    this._centralSaveService.saveTriggered$
        .pipe(filter(component => component === Components.MY_WIDGET))
        .subscribe(() => {
            if (this.myWidgetForm.dirty) {
                this.saveWidgetData();  // 👈 Your save function
            } else {
                this.closeWidgetModal();  // 👈 Optional: Close modal if no changes
            }
            this.myWidgetForm.markAsPristine();
        });
}
```

🔹 `registerSave()` ensures that your widget listens for save events.
🔹 `saveTriggered$` will notify the widget when a save is triggered.

### **💾 Step 4: Implement the Save Method**
Define a method in your component that handles the save operation.

```
saveWidgetData() {
    // Your logic to save widget settings
}
```

### **🚀 Step 5: Trigger Save from Anywhere**
Now, when you call `triggerSave()`, **all registered components** will execute their save logic.
Example:
`this._centralSaveService.triggerSave();`

🔹 Call this method when the **"Save"** button is clicked.

### ✅ **Step 6: Clear Registered Widgets When Modal Closes**
To prevent memory leaks, clear registered components when the widget modal is closed.
`this.widgetModal.onHidden.subscribe(() => this._centralSaveService.clear());`


🎉 **Done! Now Your Widget Supports Centralized Saving!**

🔹 **Every widget using this service will save when `triggerSave()` is called!**
🔹 **No need for individual save buttons—just one global save!**

💡 **Bonus Tip:** You can extend this to **multiple widgets**, ensuring all save operations happen simultaneously! 🚀🔥
